### PR TITLE
Latest Native SDK compatibility issue fixes - [iOS]

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -3,7 +3,7 @@
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
 # change version to 10.0
-platform :ios, '10.0'
+platform :ios, '11.0'
 # ====================================
 
 
@@ -58,4 +58,25 @@ target 'example-tvOS' do
     # Pods for testing
   end
 
+end
+
+post_install do |installer|
+  ## Fix for XCode 12.5
+      find_and_replace("../node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm",
+      "_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules", "_initializeModules:(NSArray<Class> *)modules")
+      find_and_replace("../node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm",
+      "RCTBridgeModuleNameForClass(module))", "RCTBridgeModuleNameForClass(Class(module)))")
+  end
+
+def find_and_replace(dir, findstr, replacestr)
+  Dir[dir].each do |name|
+      text = File.read(name)
+      replace = text.gsub(findstr,replacestr)
+      if text != replace
+          puts "Fix: " + name
+          File.open(name, "w") { |file| file.puts replace }
+          STDOUT.flush
+      end
+  end
+  Dir[dir + '*/'].each(&method(:find_and_replace))
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - Brightcove-Player-Core (6.4.5):
-    - Brightcove-Player-Core/default (= 6.4.5)
-  - Brightcove-Player-Core/default (6.4.5)
+  - Brightcove-Player-Core (6.10.2):
+    - Brightcove-Player-Core/Framework (= 6.10.2)
+  - Brightcove-Player-Core/Framework (6.10.2)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.61.2)
   - FBReactNativeSpec (0.61.2):
@@ -185,7 +185,7 @@ PODS:
     - React-cxxreact (= 0.61.2)
     - React-jsi (= 0.61.2)
   - React-jsinspector (0.61.2)
-  - react-native-brightcove-player (1.6.7):
+  - react-native-brightcove-player (1.7.0):
     - Brightcove-Player-Core
     - React
   - React-RCTActionSheet (0.61.2):
@@ -318,7 +318,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  Brightcove-Player-Core: bcd099cdc27a807ae23fcf22ecfb1eb52c72980c
+  Brightcove-Player-Core: 207189ebef308f851425fda360a149f632accf53
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 68b6a76960fbd8ecd9fb7ce0aadd3329c3340a99
   FBReactNativeSpec: 5a764c60abdc3336a213e5310c40b74741f32839
@@ -333,7 +333,7 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
-  react-native-brightcove-player: fe9ba2edbf8fa3b8e227f47bc69812dbb7107d6a
+  react-native-brightcove-player: 2e9616258ff8b1f4a6fa5e9b50a8072289b3b144
   React-RCTActionSheet: 89b037c0fb7d2671607cb645760164e7e0c013f6
   React-RCTAnimation: e3cefa93c38c004c318f7ec04b883eb14b8b8235
   React-RCTBlob: d26ac0e313fbf14e7203473fd593ccaaeee8329e
@@ -346,6 +346,6 @@ SPEC CHECKSUMS:
   ReactCommon: 5848032ed2f274fcb40f6b9ec24067787c42d479
   Yoga: 14927e37bd25376d216b150ab2a561773d57911f
 
-PODFILE CHECKSUM: 65ad9d78f2ffbb0eaa33be7e873cf89f69bb61ee
+PODFILE CHECKSUM: 82e4dd23a981544358678db9054d78084654531a
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.11.2

--- a/ios/BrightcovePlayerUtil.m
+++ b/ios/BrightcovePlayerUtil.m
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(requestDownloadVideoWithReferenceId:(NSString *)referenceId ac
             reject(kErrorCode, error.description, error);
             return;
         }
-        [[BrightcovePlayerOfflineVideoManager sharedManager] requestVideoDownload:video parameters:[self generateDownloadParameterWithBitRate:bitRate] completion:^(BCOVOfflineVideoToken offlineVideoToken, NSError *error) {
+      [[BrightcovePlayerOfflineVideoManager sharedManager] requestVideoDownload:video mediaSelections: nil parameters:[self generateDownloadParameterWithBitRate:bitRate] completion:^(BCOVOfflineVideoToken offlineVideoToken, NSError *error) {
             if (error) {
                 reject(kErrorCode, error.description, error);
                 return;
@@ -69,7 +69,7 @@ RCT_EXPORT_METHOD(requestDownloadVideoWithVideoId:(NSString *)videoId accountId:
             return;
         }
         [BrightcovePlayerOfflineVideoManager sharedManager].delegate = self;
-        [[BrightcovePlayerOfflineVideoManager sharedManager] requestVideoDownload:video parameters:[self generateDownloadParameterWithBitRate:bitRate] completion:^(BCOVOfflineVideoToken offlineVideoToken, NSError *error) {
+      [[BrightcovePlayerOfflineVideoManager sharedManager] requestVideoDownload:video mediaSelections: nil parameters:[self generateDownloadParameterWithBitRate:bitRate] completion:^(BCOVOfflineVideoToken offlineVideoToken, NSError *error)  {
             if (error) {
                 reject(kErrorCode, error.description, error);
                 return;
@@ -153,7 +153,7 @@ RCT_EXPORT_METHOD(getPlaylistWithReferenceId:(NSString *)referenceId accountId:(
         if (!description) {
             description = @"";
         }
-	NSString *referenceId = video.properties[kBCOVVideoPropertyKeyReferenceId];
+  NSString *referenceId = video.properties[kBCOVVideoPropertyKeyReferenceId];
         if (!referenceId) {
             referenceId = @"";
         }


### PR DESCRIPTION
- [SDK Upgrade] -  Upgraded the iOS project to point to the latest B'cove Native SDK 6.10.2

- [SDK Upgrade fix] - Upgraded the video download method to the latest API provided by the B'cove Native SDK. Documentation referece (https://sdks.support.brightcove.com/ios/reference/sdk/Classes/BCOVOfflineVideoManager.html#//api/name/requestVideoDownload:mediaSelections:parameters:completion:)

- [XCode Upgrade fix] - Added the Xcode 12.5 React Native Bridging module error fix in the podfile. (https://github.com/facebook/react-native/issues/31412#issuecomment-828097064)