### PR TITLE
fix: Video getting changed while click video controls on portrait ful…

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -77,7 +77,6 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         this.mediaController = new BrightcoveMediaController(this.playerVideoView);
         this.playerVideoView.setMediaController(this.mediaController);
         this.requestLayout();
-        ViewCompat.setTranslationZ(this, 9999);
         EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
             @Override

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -37,7 +37,6 @@ class BrightcovePlayer extends Component {
         style={[
           this.props.style,
           this.state.androidFullscreen && {
-            position: 'absolute',
             zIndex: 9999,
             top: 0,
             left: 0,


### PR DESCRIPTION
Video getting changed on a portrait full screen while clicking on play/pause. It's due to the click that has been taken in the playlist.