### PR TITLE
fix: Pick random video logic infinite loop

### DIFF
--- a/android/src/main/java/jp/manse/up_next/UpNextViewOverlay.java
+++ b/android/src/main/java/jp/manse/up_next/UpNextViewOverlay.java
@@ -252,7 +252,7 @@ public class UpNextViewOverlay {
     private Video getNextRandomVideo() {
         Video video = null;
         // We left the random video pick logic when there is only one on video cloud to avoid infinite loop
-        if(allVideos != null && allVideos.getVideos() != null && allVideos.getVideos().size() > 1) {
+        if (allVideos != null && allVideos.getVideos() != null && allVideos.getVideos().size() > 1) {
             while (video == null || video.getId().equals(videoId)) {
                 video = getRandomFromAllVideos();
             }

--- a/android/src/main/java/jp/manse/up_next/UpNextViewOverlay.java
+++ b/android/src/main/java/jp/manse/up_next/UpNextViewOverlay.java
@@ -251,8 +251,11 @@ public class UpNextViewOverlay {
 
     private Video getNextRandomVideo() {
         Video video = null;
-        while (video == null || video.getId().equals(videoId)) {
-            video = getRandomFromAllVideos();
+        // We left the random video pick logic when there is only one on video cloud to avoid infinite loop
+        if(allVideos != null && allVideos.getVideos() != null && allVideos.getVideos().size() > 1) {
+            while (video == null || video.getId().equals(videoId)) {
+                video = getRandomFromAllVideos();
+            }
         }
         return video;
     }


### PR DESCRIPTION
Hi @backer,
Pick random video logic infinite loop issue when video cloud has only one video in that account. Added if condition to perform if videos list more than one video.

Have a nice day